### PR TITLE
Possibility to order resources in several ways

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -84,6 +84,7 @@ Available parameters:
     **max** - Value from 0 to 50. Specify max result number per search "page". Defaults to 10.
     **before** - Search before specified date. Format YYYY-MM-DD, e.g. 2010-10-10.
     **after** - Search after specified date. Format as above.
+    **order** - Specify the method that will be used to order resources. Values: `date`, `rating`, `relevance`, `title` and `viewCount`. Default is relevance.
 
 .. note:: If ``channel`` is given, then you can ommit actual search query. Most popular videos of the channel will be returned.
 

--- a/ytfs/actions.py
+++ b/ytfs/actions.py
@@ -25,7 +25,6 @@ class YTActions():
                         "token": (`adj_tokens`, `files`),
                         ...
                     }
-                                                                        
         `adj_tokens` contains adjacent tokens, `files` contains files of given search.
         (just as described below).
     visible_files : dict
@@ -107,7 +106,6 @@ class YTActions():
         if parsed[0].get("publishedAfter"): self.search_params["publishedAfter"] += "T00:00:00Z"
 
     def __getChannelId(self):
-        
         """
         Obtain channel id for channel name, if present in ``self.search_params``.
         """
@@ -147,7 +145,7 @@ class YTActions():
             Search query to parse. Besides a search query, user can specify additional search parameters and YTFS
             specific options. Syntax:
             Additional search parameters: ``option:value``. if `value` contains spaces, then surround it with
-            parentheses; available parameters: `channel`, `max`, `before`, `after`.
+            parentheses; available parameters: `channel`, `max`, `before`, `after`, `order`.
             YTFS options: specify options between ``[`` and ``]``; Available options: `a`, `v`, `f`, `P`, `s`, `m`.
             If an option takes a parameter, then specify it beetween parentheses.
 
@@ -164,15 +162,16 @@ class YTActions():
 
         ret = dict()
 
+        ret['order'] = self.preferences['order']
+
         parse_params = True
 
         buf = ""
         ptr = ""
 
-        p_avail = ("channel", "max", "before", "after")
+        p_avail = ("channel", "max", "before", "after", "order")
 
         opts = dict()
-        
         par_open = False
 
         translate = {
@@ -186,6 +185,7 @@ class YTActions():
             'channel': 'channelId',
             'before': 'publishedBefore',
             'after': 'publishedAfter',
+            'order': 'order',
             '': 'q'
         }
 
@@ -295,7 +295,6 @@ class YTActions():
         url = api_fixed_url + urlencode(d)
 
         get = requests.get(url) #FIXME? something can go wrong here...
-        
         if get.status_code != 200:
             return {'items': []} # no valid query - no results.
 
@@ -425,7 +424,6 @@ class YTActions():
                 data = self.avail_files[ self.adj_tokens[forward] ] # maybe data is already available locally.
             except KeyError:
                 recv = self.__search( self.adj_tokens[forward] ) # nope, we have to search.
-                                                                                                 
         except KeyError: # wrong index in adj_tokens
 
             if forward is None:

--- a/ytfs/ytfs.py
+++ b/ytfs/ytfs.py
@@ -77,7 +77,6 @@ class fd_dict(dict):
         yts : YTStor-obj or None
             ``YTStor`` object for which we want to allocate a descriptor or ``None``, if we allocate descriptor for a
             control file.
-     
         Returns
         -------
         k : int
@@ -107,7 +106,6 @@ class YTFS(Operations):
     searches : dict
         Dictionary that is a main interface to data of idividual searches and their results (movies) stored by
         filesystem. Format:
-        
           searches = {
               'search phrase 1':  YTActions({
                                        'tytul1': <YTStor obj>,
@@ -117,7 +115,6 @@ class YTFS(Operations):
               'search phrase 2':  YTActions({ ... }),
               ...
           }
-        
         ``YTStor`` object stores all needed information about movie, not only multimedia data.
 
         Attention: for simplicity, file extensions are present only during directory listing. In all other operations
@@ -210,7 +207,6 @@ class YTFS(Operations):
                 return YTFS.PathType.subdir
 
             elif p[0] and p[1]:
-                
                 if p[1][0] == ' ':
                     return YTFS.PathType.ctrl
                 else:
@@ -360,7 +356,6 @@ class YTFS(Operations):
         st['st_ctime'] = st['st_atime']
 
         if pt is self.PathType.file:
-            
             st['st_mode'] = stat.S_IFREG | 0o444
             st['st_nlink'] = 1
 
@@ -535,7 +530,6 @@ class YTFS(Operations):
 
         """
         File open. ``YTStor`` object associated with this file is initialised and written to ``self.fds``.
-        
         Parameters
         ----------
         tid : str
@@ -698,6 +692,9 @@ def main():
     parser.add_argument('-d', action='store_true', default=False, help="debug: run in foreground")
     parser.add_argument('-m', default="", help="Metadata to fetch. Values: `desc` for descriptions, `thumb` for thumbnails. Use comma (,) for separating multiple values.", metavar="META1[,META2[,...]]")
 
+    avgrp.add_argument('-o', choices=['date', 'rating', 'relevance', 'title', 'viewCount'], default='relevance',
+                        help='Specify the method that will be used to order resources. Values: `date`, `rating`, `relevance`, `title` and `viewCount`. Default is relevance.')
+
     x = parser.parse_args()
 
     if x.a:
@@ -719,6 +716,7 @@ def main():
         for m in x.m.split(','):
             YTActions.preferences['metadata'][m] = True
 
+    YTActions.preferences['order'] = x.o
 
     print("Mounting YTFS ver. " + __version__ + ".\nIf you encounter any bugs, please open an issue on GitHub: https://github.com/rasguanabana/ytfs")
 


### PR DESCRIPTION
It can sort by title, view count, relevance, rating and date.
It is possible to create a global preference using -o option and
using order param in a search.

This fixes #14.
