### PR TITLE
Add encoding to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 from setuptools import setup
 
 import re


### PR DESCRIPTION
Fixes:
$ python setup.py --command-packages=stdeb.command debianize
  File "setup.py", line 19
SyntaxError: Non-ASCII character '\xc5' in file setup.py on line 19, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
